### PR TITLE
Added a simple way to configure your own reporter to store coverage data

### DIFF
--- a/lib/coverband/base.rb
+++ b/lib/coverband/base.rb
@@ -41,7 +41,7 @@ module Coverband
       @startup_delay = Coverband.configuration.startup_delay
       @ignore_patterns = Coverband.configuration.ignore
       @sample_percentage = Coverband.configuration.percentage
-      @reporter = Coverband::RedisStore.new(Coverband.configuration.redis) if Coverband.configuration.redis
+      @reporter = Coverband.configuration.reporter || (Coverband.configuration.redis && Coverband::RedisStore.new(Coverband.configuration.redis))
       @stats    = Coverband.configuration.stats
       @verbose  = Coverband.configuration.verbose
       @logger   = Coverband.configuration.logger

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -1,6 +1,6 @@
 module Coverband
   class Configuration
-    attr_accessor :redis, :coverage_baseline, :root_paths, :root, :ignore, :percentage, :verbose, :reporter, :stats, :logger, :startup_delay, :baseline_file
+    attr_accessor :redis, :coverage_baseline, :root_paths, :root, :ignore, :percentage, :verbose, :reporter, :stats, :logger, :startup_delay, :baseline_file, :reporter
     
     def initialize
       @root = Dir.pwd
@@ -15,6 +15,7 @@ module Coverband
       @reporter = 'scov'
       @logger = Logger.new(STDOUT)
       @startup_delay = 0
+      @reporter = nil
     end
 
     def logger


### PR DESCRIPTION
Added a very simple way to configure our own reporter. Coverband's report generation will not work with this as it still uses the redis interface. But we'll worry about that once we actually start getting events in Kafka.

@eapache
